### PR TITLE
Unless  [The Language of Macros]

### DIFF
--- a/lib/macros/unless.exs
+++ b/lib/macros/unless.exs
@@ -1,0 +1,7 @@
+defmodule ControlFlow do
+  defmacro unless(expression, do: block) do
+    quote do
+      if !unquote(expression), do: unquote(block)
+    end
+  end
+end

--- a/lib/macros/unless_without_if.exs
+++ b/lib/macros/unless_without_if.exs
@@ -1,0 +1,9 @@
+defmodule ControlFlow do
+  defmacro unless(expression, do: block) do
+    quote do
+      cond do
+        !unquote(expression) -> unquote(block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Let’s pretend for a moment that Elixir lacks a built-in unless construct. In most
languages, we would have to settle for if ! expressions and learn to accept this
syntactic shortcoming.
Fortunately for us, Elixir isn’t like most languages. Let’s define our own unless
macro, using if as a building block of our implementation. Macros must be
defined within modules, so let’s define a ControlFlow module