### PR TITLE
Callers Context [The Language of Macros]

### DIFF
--- a/lib/macros/callers_context.exs
+++ b/lib/macros/callers_context.exs
@@ -1,0 +1,21 @@
+defmodule Mod do
+  defmacro definfo do
+    IO.puts("In macro's context (#{__MODULE__}).")
+
+    quote do
+      IO.puts("In caller's context (#{__MODULE__}).")
+
+      def friendly_info do
+        IO.puts("""
+        My name is #{__MODULE__}
+        My functions are #{inspect(__MODULE__.__info__(:functions))})
+        """)
+      end
+    end
+  end
+end
+
+defmodule MyModule do
+  require Mod
+  Mod.definfo()
+end


### PR DESCRIPTION
> Because macros are all about injecting code, you have to understand the two
> contexts in which a macro executes, or you risk generating code in the wrong
> place. One is the context of the macro definition, and the other is the caller’s
> invocation of the macro. Let’s see this in action by defining a definfo macro
> that prints a module’s information in a friendly format while showing what
> context the code is executing in.