### PR TITLE
If recreated [Extending Elixir with Metaprogramming]

### DIFF
--- a/lib/macros/if_recreated.exs
+++ b/lib/macros/if_recreated.exs
@@ -1,0 +1,12 @@
+defmodule ControlFlow do
+  defmacro my_if(expr, do: if_block), do: if(expr, do: if_block, else: nil)
+
+  defmacro my_if(expr, do: if_block, else: else_block) do
+    quote do
+      case unquote(expr) do
+        result when result in [false, nil] -> unquote(else_block)
+        _ -> unquote(if_block)
+      end
+    end
+  end
+end


### PR DESCRIPTION
> Let’s try out this idea. Consider the if macro from our unless example in the
> code on page 11. The if macro might appear special, but we know it’s a macro
> like any other. Let’s re-create Elixir’s if macro to get a taste of how easy it is
> to implement features using the building blocks of the language.