### PR TITLE
Adding a while Loop to Elixir [Extending Elixir with Metaprogramming]

### DIFF
--- a/lib/macros/while.exs
+++ b/lib/macros/while.exs
@@ -1,0 +1,19 @@
+defmodule Loop do
+  defmacro while(expression, do: block) do
+    quote do
+      try do
+        for _ <- Stream.cycle([:ok]) do
+          if unquote(expression) do
+            unquote(block)
+          else
+            Loop.break()
+          end
+        end
+      catch
+        :break -> :ok
+      end
+    end
+  end
+
+  def break, do: :break
+end

--- a/lib/macros/while_step1.exs
+++ b/lib/macros/while_step1.exs
@@ -1,0 +1,17 @@
+defmodule Loop do
+  defmacro while(expression, do: block) do
+    quote do
+      try do
+        for _ <- Stream.cycle([:ok]) do
+          if unquote(expression) do
+            unquote(block)
+          else
+            throw(:break)
+          end
+        end
+      catch
+        :break -> :ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
We’ll extend Elixir with a new while macro that loops repeatedly with the ability to break out of its own execution. Here’s an example of the feature we’re
going to create:
```
while Process.alive?(pid) do
   send pid, {self, :ping}
   receive do
      {^pid, :pong} -> IO.puts "Got pong"
      after 2000 -> break
   end
end
```
When creating a feature like this, it’s best to start by choosing which Elixir
building blocks will be required to accomplish your high-level goals. Our main
issue is that Elixir has no built-in way to loop infinitely. So how are we to
handle a repetitive loop without such a feature? We cheat. We can get creative
by consuming